### PR TITLE
Create Pusher w/ Options from config

### DIFF
--- a/BroadcastManager.php
+++ b/BroadcastManager.php
@@ -121,7 +121,7 @@ class BroadcastManager implements FactoryContract
     protected function createPusherDriver(array $config)
     {
         return new PusherBroadcaster(
-            new Pusher($config['key'], $config['secret'], $config['app_id'])
+            new Pusher($config['key'], $config['secret'], $config['app_id'], $config['options'])
         );
     }
 


### PR DESCRIPTION
# Pusher Options Addition

Added the parameter to pass in options from the broadcasting configuration to the Pusher class if needed. This goes in tangent with the [PR request](https://github.com/laravel/laravel/pull/3512) for `laravel/laravel`.
